### PR TITLE
pass docker image flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,9 +57,9 @@ function undeploy ({ projectLocation, strictSSL, removeAll }) {
     nodeshift.undeploy({ projectLocation, strictSSL, removeAll });
 }
 
-function build ({ projectLocation, strictSSL }) {
+function build ({ projectLocation, strictSSL, dockerImage, nodeVersion }) {
   return async () =>
-    nodeshift.build({ projectLocation, strictSSL });
+    nodeshift.build({ projectLocation, strictSSL, dockerImage, nodeVersion });
 }
 
 function applyResources ({ projectLocation, strictSSL }) {
@@ -69,8 +69,8 @@ function applyResources ({ projectLocation, strictSSL }) {
     .catch(console.error);
 }
 
-function runDeploy ({ projectLocation, strictSSL }) {
-  return nodeshift.deploy({ projectLocation, strictSSL })
+function runDeploy ({ projectLocation, strictSSL, dockerImage, nodeVersion }) {
+  return nodeshift.deploy({ projectLocation, strictSSL, dockerImage, nodeVersion })
     .then(getRoute)
     .catch(console.error);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1083,6 +1083,18 @@
         "text-table": "0.2.0"
       }
     },
+    "eslint-config-semistandard": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-semistandard/-/eslint-config-semistandard-12.0.1.tgz",
+      "integrity": "sha512-4zaPW5uRFasf2uRZkE19Y+W84KBV3q+oyWYOsgUN+5DQXE5HCsh7ZxeWDXxozk7NPycGm0kXcsJzLe5GZ1jCeg==",
+      "dev": true
+    },
+    "eslint-config-standard": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-11.0.0.tgz",
+      "integrity": "sha512-oDdENzpViEe5fwuRCWla7AXQd++/oyIp8zP+iP9jiUPG6NBj3SHgdgtl/kTn00AjeN+1HNvavTKmYbMo+xMOlw==",
+      "dev": true
+    },
     "eslint-import-resolver-node": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
@@ -2309,9 +2321,9 @@
       "dev": true
     },
     "nodeshift": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/nodeshift/-/nodeshift-1.5.0.tgz",
-      "integrity": "sha512-vFdtf5EgP7a7srhWm/KxI0+4ftgbeVj6kE6GMrSsKZLqSp3ASeMY/60mcaRfa2JRbhxmGRuas3FW1vLCluOpjg==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/nodeshift/-/nodeshift-1.5.1.tgz",
+      "integrity": "sha512-tMTsexbu847AjyYSxbp4C4mlx+SyCVQqCYWs563GLspQWOh+J7Faf+WGHYqlxspViIYrQkP0/OOOmSQvdSyUKQ==",
       "requires": {
         "chalk": "2.3.1",
         "git-repo-info": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "tape": "^4.8.0"
   },
   "dependencies": {
-    "nodeshift": "~1.5.0",
+    "nodeshift": "^1.5.1",
     "openshift-config-loader": "~0.4.0",
     "openshift-rest-client": "^1.0.1"
   }

--- a/test/test.js
+++ b/test/test.js
@@ -15,11 +15,24 @@ test('Instance creation', t => {
 });
 
 test('Default options', t => {
-  t.plan(4);
+  t.plan(5);
   const testEnv = rhoaster();
   t.strictEqual(testEnv.opts.deploymentName, 'rhoaster', 'deploymentName');
   t.strictEqual(path.basename(testEnv.opts.projectLocation), 'rhoaster', 'projectLocation');
   t.false(testEnv.opts.forceDeploy, 'forceDeploy');
   t.false(testEnv.opts.strictSSL, 'strictSSL');
+  t.true(testEnv.opts.removeAll, 'removeAll');
+  t.end();
+});
+
+test('dockerImage and nodeVersion options', t => {
+  t.plan(2);
+  const options = {
+    dockerImage: 'registry.access.redhat.com/rhoar-nodejs/nodejs-8',
+    nodeVersion: '8.x'
+  };
+  const testEnv = rhoaster(options);
+  t.strictEqual(testEnv.opts.dockerImage, options.dockerImage, 'dockerImage');
+  t.strictEqual(testEnv.opts.nodeVersion, options.nodeVersion, 'nodeVersion');
   t.end();
 });


### PR DESCRIPTION
the boosters we are testing out have been specifying a nodeVersion, and now the "produciton" boosters need to change the s2i image we test with.

This allows those options to now be passed through to nodeshift


First commit also updates nodeshift to the latest version

fixes #9 